### PR TITLE
Typo in platform_frameworks_base definition

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -172,7 +172,7 @@
   <project path="external/libevent" name="platform/external/libevent" />
   <project path="external/libexif" name="platform/external/libexif" groups="pdk-cw-fs,pdk-fs" />
   <project path="external/libgsm" name="platform/external/libgsm" groups="pdk" />
-  <project path="external/libhevc" name="external_libhevc" remote="ads" revison="ads-7.1.0" groups="pdk-fs" />
+  <project path="external/libhevc" name="external_libhevc" remote="ads" revision="ads-7.1.0" groups="pdk-fs" />
   <project path="external/libjpeg-turbo" name="platform/external/libjpeg-turbo" groups="pdk" />
   <project path="external/liblzf" name="platform/external/liblzf" groups="pdk" />
   <project path="external/libmicrohttpd" name="platform/external/libmicrohttpd" />

--- a/default.xml
+++ b/default.xml
@@ -294,7 +294,7 @@
   <project path="external/zopfli" name="platform/external/zopfli" groups="pdk-cw-fs,pdk-fs" />
   <project path="external/zxing" name="platform/external/zxing" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/av" name="android_frameworks_av" remote="ads" revision="ads-7.1.0" groups="pdk" />
-  <project path="frameworks/base" name="platform_frameworks_base" remote="ads" revision"ads-7.1.0" groups="pdk-cw-fs,pdk-fs" />
+  <project path="frameworks/base" name="platform_frameworks_base" remote="ads" revision="ads-7.1.0" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/compile/libbcc" name="platform/frameworks/compile/libbcc" groups="pdk" />
   <project path="frameworks/compile/mclinker" name="platform/frameworks/compile/mclinker" groups="pdk" />
   <project path="frameworks/compile/slang" name="platform/frameworks/compile/slang" groups="pdk" />


### PR DESCRIPTION
I spotted a typo in default.xml following recent published changes to the repo  